### PR TITLE
Fix parameter mismatch in SWOT card

### DIFF
--- a/app_gen.py
+++ b/app_gen.py
@@ -178,8 +178,8 @@ def render_kpis(kpi_sugestoes):
                 st.metric(label=kpi_sug.get("titulo","KPI"),value=str(params.get("valor","N/A")),delta=delta_val if delta_val else None,help=params.get("descricao"))
         st.divider()
 
-def render_swot_card(titulo_completo_swot, swot_data):
-    st.subheader(f"{titulo_completo_swot}") 
+def render_swot_card(titulo_completo_swot, swot_data, card_key_prefix=None):
+    st.subheader(f"{titulo_completo_swot}")
     col1, col2 = st.columns(2)
     swot_map = {"forcas": ("Forças 💪", col1), "fraquezas": ("Fraquezas 📉", col1), 
                 "oportunidades": ("Oportunidades 🚀", col2), "ameacas": ("Ameaças ⚠️", col2)}


### PR DESCRIPTION
## Summary
- allow `render_swot_card` to accept `card_key_prefix`

## Testing
- `python3 -m py_compile app_gen.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the SWOT card display with improved flexibility for future updates. No visible changes to current functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->