### PR TITLE
Add LLM provider option

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,7 @@ pandas
 python-docx
 plotly
 google-generativeai
+openai
+anthropic
 tabulate
-openpyxl 
+openpyxl


### PR DESCRIPTION
## Summary
- add ability to choose Gemini, Claude or OpenAI
- generalize analysis routine to support multiple models
- include API helpers and dependencies for openai/anthropic

## Testing
- `python3 -m py_compile app_gen.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for selecting and using multiple AI providers (Gemini, OpenAI, Claude) for document analysis.
	- Introduced a dropdown in the sidebar for users to choose their preferred AI provider.

- **Improvements**
	- Updated user interface text to reflect generic AI provider support.
	- Enhanced error handling and debugging information for different providers.

- **Chores**
	- Added required dependencies for OpenAI and Anthropic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->